### PR TITLE
refactor: Supabase selects auf spezifische Spalten einschränken

### DIFF
--- a/src/lib/services/media.service.ts
+++ b/src/lib/services/media.service.ts
@@ -294,7 +294,13 @@ export class MediaService {
     const offset = (page - 1) * limit;
 
     try {
-      let query = this.supabase.from("media").select("*", { count: "exact" });
+      // Wähle nur die benötigten Felder aus, um die Payload zu reduzieren. `count: "exact"` bleibt erhalten.
+      let query = this.supabase
+        .from("media")
+        .select(
+          "id, original_name, file_name, file_path, file_size, mime_type, media_type, directory, uploaded_at, uploaded_by, tags, is_public, metadata",
+          { count: "exact" },
+        );
 
       // Apply filters
       if (search) {
@@ -363,9 +369,12 @@ export class MediaService {
    */
   async getMediaItem(id: string): Promise<MediaItem> {
     try {
+      // Wähle nur die benötigten Felder aus, um Transfergröße zu reduzieren.
       const result = await this.supabase
         .from("media")
-        .select("*")
+        .select(
+          "id, original_name, file_name, file_path, file_size, mime_type, media_type, directory, uploaded_at, uploaded_by, tags, is_public, metadata",
+        )
         .eq("id", id)
         .single();
 

--- a/src/server/api/routers/auth.ts
+++ b/src/server/api/routers/auth.ts
@@ -67,9 +67,12 @@ export const authRouter = createTRPCRouter({
       throw new Error("Admin-Rechte erforderlich");
     }
 
+    // Wähle nur die benötigten Felder aus der Tabelle, um die Datenmenge zu minimieren.
     const usersResult = await _ctx.db
       .from("user_profiles")
-      .select("*")
+      .select(
+        "user_id, email, role, name, created_at, updated_at",
+      )
       .order("created_at", { ascending: false });
 
     const { data: users, error } = usersResult as {


### PR DESCRIPTION
Optimiert Datenabfragen durch gezielte Spaltenwahl statt select('*'). Reduziert Datenmenge, beschleunigt Ladezeit. Details siehe Patchbeschreibung.